### PR TITLE
Fix azd race condition

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -124,6 +124,7 @@ module mcpApiModule './app/apim-mcp/mcp-api.bicep' = {
   dependsOn: [
     appServicePlan
     api
+    storagePrivateEndpoint
   ]
 }
 


### PR DESCRIPTION
When running azd up, there was an intermittent issue caused by race conditions: 

```
ERROR: error executing step command 'provision': deployment failed: error deploying infrastructure: deploying to subscription:
 
Deployment Error Details:
BadRequest: Encountered an error (InternalServerError) from host runtime.
- Encountered an error (InternalServerError) from host runtime.
```

We believe this happens because `mcpApiModule` needs a function key from the function's host. But the private endpoint might be in the middle of setting up, so the host can't get the key from the storage account. Thus, we added `storagePrivateEndpoint` as a dependsOn component in the `mcpApiModule`.