### PR TITLE
Fix .funcignore for remote build and add remoteBuild to azure.yaml

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -1,5 +1,4 @@
 *.js.map
-*.ts
 .git*
 .vscode
 __azurite_db*__.json
@@ -7,4 +6,4 @@ __blobstorage__
 __queuestorage__
 local.settings.json
 test
-tsconfig.json
+node_modules

--- a/azure.yaml
+++ b/azure.yaml
@@ -8,3 +8,4 @@ services:
     project: .
     language: js
     host: function
+    remoteBuild: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -6,6 +6,6 @@ metadata:
 services:
   mcp:
     project: .
-    language: js
+    language: ts
     host: function
     remoteBuild: true


### PR DESCRIPTION
## Summary

Fixes the project configuration for remote build when deploying with `azd`.

## Changes

- **azure.yaml**: Added `remoteBuild: true` under the `mcp` service
- **.funcignore**: Reconfigured for remote build — removed `*.ts` and `tsconfig.json` from ignore list, added `node_modules`

## Context

When deploying Node.js/TypeScript Azure Functions apps with `azd`, remote build is used. The previous `.funcignore` was configured for local build: it ignored `*.ts` and `tsconfig.json` (preventing remote compilation) and did not ignore `node_modules` (uploading all dependencies). This change flips the configuration so source files are included and `node_modules` are excluded, allowing remote build to compile TypeScript and install dependencies correctly.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.